### PR TITLE
`ldconfig` now handled by quick-sharun

### DIFF
--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -36,13 +36,6 @@ LOCALEDIR = os.path.join(SHARUN_DIR, '"'"'share'"'"', '"'"'locale'"'"')' ./AppDi
 sed -i 's|const.PKGDATADIR|PKGDATADIR|' ./AppDir/bin/secrets
 sed -i 's|const.LOCALEDIR|LOCALEDIR|' ./AppDir/bin/secrets
 
-sed -i -e 's|/etc/ld.so.cache|/tmp/ld.so.cache|g' ./AppDir/bin/ldconfig
-echo '#!/bin/sh
-if command -v ldconfig 1>/dev/null && [ ! -f /tmp/ld.so.cache ]; then
-	exec ldconfig
-fi
-' > ./AppDir/bin/ldconfig.hook
-chmod +x ./AppDir/bin/ldconfig.hook
 
 # Turn AppDir into AppImage
 quick-sharun --make-appimage


### PR DESCRIPTION
https://github.com/pkgforge-dev/Anylinux-AppImages/commit/1053d356f67f0079d9225b163406bc94a3f7cb82

the `PATH_MAPPING` is still needed since python hardcodes `/sbin/ldconfig`